### PR TITLE
Saltstack default settings

### DIFF
--- a/honeyswarm_template.env
+++ b/honeyswarm_template.env
@@ -5,6 +5,7 @@ TIMEZONE=Europe/London
 SALT_USERNAME=salt
 SALT_SHARED_SECRET=CHANGE_ME_I_AM_NOT_SECURE
 SALT_HOST=https://saltmaster:8000
+SALT_MASTER_CONFIG={"netapi_enable_clients":["local","local_async","wheel","runner"]}
 
 # Flask Shell
 FLASK_APP=honeyswarm.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-flask
+flask==2.2.5  
 flask-login
 mongoengine
 flask-mongoengine
 flask-security-too
+flask_security==3.0.0
 distro
 flask
 pytz


### PR DESCRIPTION
By default new releases of salt stack need to have `netapi_enable_clients` configured. By default all clients are disabled. 